### PR TITLE
하우징 띄우기 버튼 기능 구현

### DIFF
--- a/Assets/DongHyuk/Prefabs/LeftHandUI.prefab
+++ b/Assets/DongHyuk/Prefabs/LeftHandUI.prefab
@@ -1458,11 +1458,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -2147,11 +2147,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -2317,11 +2317,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: d6e52bc1b8fc5554eaef0f65018bea0b,
+    m_HighlightedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: e34f3ef561c885a4aaf2e85b41b5d927, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: bd1b74a9df1722041bbd1719e90cd36f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -4493,11 +4493,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -4663,11 +4663,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: d6e52bc1b8fc5554eaef0f65018bea0b,
+    m_HighlightedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: e34f3ef561c885a4aaf2e85b41b5d927, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: bd1b74a9df1722041bbd1719e90cd36f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -5156,11 +5156,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -6803,11 +6803,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -7948,11 +7948,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -8219,11 +8219,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 66e4ea8847003fa49a3ecb7d7a7bcd88,
+    m_HighlightedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: d389187729dc1c14eabf06227673695f, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: 603d75921c1b2364a954cf853781689f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: e8d109d9a841d7e4c88b5e813cc07e7e, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -8469,11 +8469,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: eaf4ef537ccc2474eb93c68035783e31,
+    m_HighlightedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: 45f70e19835eeeb41b9f422153d66c13, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: de226899dfbfdeb4e8ad0be5b2edffd2, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -8716,11 +8716,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: d6e52bc1b8fc5554eaef0f65018bea0b,
+    m_HighlightedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: e34f3ef561c885a4aaf2e85b41b5d927, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: bd1b74a9df1722041bbd1719e90cd36f, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: ae67ae168daa71e45a79b6149451dcff, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -8963,11 +8963,11 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: eaf4ef537ccc2474eb93c68035783e31,
+    m_HighlightedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: 45f70e19835eeeb41b9f422153d66c13, type: 3}
-    m_SelectedSprite: {fileID: 21300000, guid: de226899dfbfdeb4e8ad0be5b2edffd2, type: 3}
-    m_DisabledSprite: {fileID: 21300000, guid: d6ec6cf3e2f1fc148815f15166f3a6c0, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: c5a149d8324d6d74fad032de80c545ef, type: 3}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
@@ -9475,22 +9475,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   exitBtn: {fileID: 8391591036810955669}
+  uiCanvas: {fileID: 0}
   overlayCanvas: {fileID: 4082658276540312334}
-  trackingStat:
-    statMin: 0
-    statMax: 100
-    expMax: 100
-    levelMax: 10
-    fullness: 0
-    tiredness: 0
-    cleanliness: 0
-    exp: 0
-    level: 0
-    health: 0
-    speed: 0
-    reactionSpeed: 0
-    jumpPower: 0
-    disobedienceRate: 0
   statUIList:
   - statName: 0
     slider: {fileID: 0}

--- a/Assets/DongHyuk/Scripts/ButtonManager.cs
+++ b/Assets/DongHyuk/Scripts/ButtonManager.cs
@@ -649,13 +649,16 @@ public class ButtonManager : MonoBehaviour
                     {
                         buttonItSelf.transform.GetChild(0).gameObject.SetActive(false);
                         buttonItSelf.transform.GetChild(1).gameObject.SetActive(true);
-                        MapInfo.Instance.SetMapNormalmode(); // 이건 하우징을 수정모드가 아니라 보기모드로 바꾸는 것임. SetVisible 머지되면 가져와야함.
+                        MapInfo.Instance.SetVisiblemode();
+                        MapInfo.Instance.SetReScale(6.4f);
+                        Debug.Log("맵이 현실과 유사한 사이즈로 생성되었습니다.");
                     }
                     else
                     {
                         buttonItSelf.transform.GetChild(0).gameObject.SetActive(true);
                         buttonItSelf.transform.GetChild(1).gameObject.SetActive(false);
                         MapInfo.Instance.SetInvisiblemode();
+                        Debug.Log("맵이 꺼졌습니다. 꺼져.");
                     }
                 }
                 break;

--- a/Assets/DongHyuk/Scripts/ButtonManager.cs
+++ b/Assets/DongHyuk/Scripts/ButtonManager.cs
@@ -46,12 +46,14 @@ public class ButtonManager : MonoBehaviour
     {
         if(ButtonMng.transform.parent.GetChild(radialNum - 1).transform.childCount == 0)
                 {
+                    Debug.Log(ButtonMng.transform.parent.GetChild(radialNum - 1).name);
                     Debug.Log("기존 Radial에 존재하던 오브젝트가 없어 새로 생성합니다.");
                 }
                 else
                 {
+                    Debug.Log(ButtonMng.transform.parent.GetChild(radialNum - 1).name);
                     Debug.Log("기존 Radial에 존재하던 오브젝트를 파괴하고 새 오브젝트로 대체합니다.");
-                    Destroy(ButtonMng.transform.parent.GetChild(radialNum + 1).transform.GetChild(0));
+                    Destroy(ButtonMng.transform.parent.GetChild(radialNum - 1).transform.GetChild(0).gameObject);
                 }
     } 
 
@@ -91,8 +93,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj1.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj1.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj1.transform.localScale *= 1000f;
-                    RadialObj1.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj1.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj1.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj1.name);
                 }
                 catch
@@ -131,8 +135,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj2.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj2.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj2.transform.localScale *= 1000f;
-                    RadialObj2.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj2.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj2.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj2.name);
                 }
                 catch
@@ -167,9 +173,11 @@ public class ButtonManager : MonoBehaviour
                         }*/
                     }
                     // 중력속성, 크기, 위치 등 조정
-                    RadialObj3.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj3.GetComponent<Rigidbody>().useGravity = false;
+                    RadialObj3.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj3.transform.localScale *= 1000f;
-                    RadialObj3.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj3.transform.localPosition += new Vector3(55.0f, 40.0f, -20.0f); 
+                    RadialObj3.transform.eulerAngles += new Vector3(180.0f, 0.0f, 90.0f);
                     Debug.Log(RadialObj3.name);
                 }
                 catch
@@ -205,8 +213,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj4.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj4.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj4.transform.localScale *= 1000f;
-                    RadialObj4.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj4.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj4.transform.eulerAngles += new Vector3(0.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj4.name);
                 }
                 catch
@@ -242,8 +252,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj5.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj5.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj5.transform.localScale *= 1000f;
-                    RadialObj5.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj5.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj5.transform.eulerAngles += new Vector3(-90.0f, 0.0f, -90.0f);
                     Debug.Log(RadialObj5.name);
                 }
                 catch
@@ -282,8 +294,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj1.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj1.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj1.transform.localScale *= 1000f;
-                    RadialObj1.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj1.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj1.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj1.name);
                 }
                 catch
@@ -322,8 +336,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj2.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj2.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj2.transform.localScale *= 1000f;
-                    RadialObj2.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj2.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj2.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj2.name);
                 }
                 catch
@@ -359,8 +375,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj3.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj3.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj3.transform.localScale *= 1000f;
-                    RadialObj3.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj3.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj3.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj3.name);
                 }
                 catch
@@ -396,8 +414,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj4.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj4.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj4.transform.localScale *= 1000f;
-                    RadialObj4.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj4.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj4.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj4.name);
                 }
                 catch
@@ -435,9 +455,11 @@ public class ButtonManager : MonoBehaviour
                         }*/
                     }
                     // 중력속성, 크기, 위치 등 조정
-                    RadialObj1.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj1.GetComponent<Rigidbody>().useGravity = false; 
+                    RadialObj1.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj1.transform.localScale *= 1000f;
-                    RadialObj1.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj1.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj1.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj1.name);
                 }
                 catch
@@ -476,8 +498,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj2.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj2.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj2.transform.localScale *= 1000f;
-                    RadialObj2.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj2.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj2.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj2.name);
                 }
                 catch
@@ -513,8 +537,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj3.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj3.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj3.transform.localScale *= 1000f;
-                    RadialObj3.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj3.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj3.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj3.name);
                 }
                 catch
@@ -550,8 +576,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj4.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj4.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj4.transform.localScale *= 1000f;
-                    RadialObj4.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj4.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj4.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj4.name);
                 }
                 catch
@@ -587,8 +615,10 @@ public class ButtonManager : MonoBehaviour
                     }
                     // 중력속성, 크기, 위치 등 조정
                     RadialObj5.GetComponent<Rigidbody>().useGravity = false;  
+                    RadialObj5.GetComponent<Rigidbody>().isKinematic = true;
                     RadialObj5.transform.localScale *= 1000f;
-                    RadialObj5.transform.localPosition += new Vector3(0.0f, 0.0f, -20.0f); 
+                    RadialObj5.transform.localPosition += new Vector3(0.0f, 40.0f, -20.0f); 
+                    RadialObj5.transform.eulerAngles += new Vector3(-90.0f, 0.0f, 0.0f);
                     Debug.Log(RadialObj5.name);
                 }
                 catch

--- a/Assets/TaeHyeon/Scenes/InteractMode.unity
+++ b/Assets/TaeHyeon/Scenes/InteractMode.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028305, g: 0.22571313, b: 0.3069213, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -6038,7 +6038,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2000651716}
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: 0, y: -0.5, z: 1}
+  m_LocalPosition: {x: 0, y: -0.595, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6592,8 +6592,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2145034644}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: -0.595, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/TaeSeung/Shader/Making Shader/URP/Shader_graph_grid.mat
+++ b/Assets/TaeSeung/Shader/Making Shader/URP/Shader_graph_grid.mat
@@ -56,7 +56,7 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 0.89411765}
     - _DefaultScale: {r: 10, g: 10, b: 0, a: 0}
-    - _Size: {r: 16, g: 16, b: 0, a: 0}
+    - _Size: {r: 6.4, g: 6.4, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &3011042100832551342
 MonoBehaviour:


### PR DESCRIPTION
<!-- PR 제목은 간결하게 작성해주세요 -->

## ✨ 변경 사항
<!-- 변경 사항에 대한 설명을 적어주세요 -->
1. 인터랙션 모드에서 하우징 띄우기 버튼으로 하우징 띄움(setReScale(6.4)로)
2. 하우징 높이에 맞춰 InteractionMode의 Floor와 Selected Spawn Position을 -0.5에서 -0.595로 변경함. (추후 보물상자 y좌표도 -.0595로 수정 필요)
3. InteractionMode의 Floor범위(스케일)을 0.8배로 수정함(하우징보다 조금 넓은 범위로 나타나게)


## 📚 새로 알게 된 내용 혹은 궁금한 사항
<!-- 참고할 사항이 있다면 적어주세요 -->



## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


